### PR TITLE
Add boolean functions

### DIFF
--- a/suggest.el
+++ b/suggest.el
@@ -40,6 +40,12 @@
 (defvar suggest-functions
   (list
    ;; TODO: add funcall, apply and map?
+   ;; Boolean functions
+   #'not
+   #'booleanp
+   #'consp
+   #'numberp
+   #'stringp
    ;; Built-in functions that access or examine lists.
    ;; TODO: why isn't car marked as pure?
    #'car
@@ -634,7 +640,7 @@ This is primarily for quoting symbols."
     ;; See if (func value1 value2...) gives us a value.
     (-when-let (result (suggest--call func input-values input-literals))
       (push result outputs))
-    
+
     ;; See if (apply func input-values) gives us a value.
     (when (and (eq (length input-values) 1) (listp (car input-values)))
       (-when-let (result (suggest--call func input-values input-literals t))
@@ -699,7 +705,7 @@ than their values."
                        (cl-incf possibilities-count)
                        (when (>= possibilities-count suggest--max-possibilities)
                          (throw 'done nil))
-                       
+
                        ;; If we're on the first iteration, we're just
                        ;; searching all input permutations. Don't try any
                        ;; other permutations, or we end up showing e.g. both
@@ -794,7 +800,7 @@ than their values."
     (setq possibilities
           (-take 5
                  (-sort #'suggest--cmp-relevance possibilities)))
-    
+
     (if possibilities
         (suggest--write-suggestions
          possibilities


### PR DESCRIPTION
It looks like for the most part, boolean p-functions (`numberp`, `stringp`, `consp`) are included in the results when the output is `t`, but not when the output is `nil`. For instance, the query `[5] => nil` might be expected to return `(stringp 5)`. Functions that operate on booleans (`booleanp`, `not`) don't seem to show up at all.

Maybe `suggest` is fundamentally list-oriented, and the output `nil` is interpreted as a list, rather than a boolean. Perhaps the split is due to the [arguably dumb choice](https://mitpress.mit.edu/sicp/full-text/book/book-Z-H-15.html#footnote_Temp_158) in Emacs to use the empty list for false instead of a dedicated boolean symbol.

```
;; Inputs (one per line):
5

;; Desired output:
t

;; Suggestions:
(numberp 5) ;=> t
(last t 5) ;=> t
(remove 5 t) ;=> t
(plist-member t 5) ;=> t
(cdr (cons 5 t)) ;=> t
```

```
;; Inputs (one per line):
5

;; Desired output:
nil

;; Suggestions:
(elt nil 5) ;=> nil
(nth 5 nil) ;=> nil
(remq 5 nil) ;=> nil
(last nil 5) ;=> nil
(-drop 5 nil) ;=> nil
```

```
;; Inputs (one per line):
"string"

;; Desired output:
t

;; Suggestions:
(stringp "string") ;=> t
(remove "string" t) ;=> t
(plist-member t "string") ;=> t
(cdr (cons "string" t)) ;=> t
(car (cons t "string")) ;=> t
```

```
;; Inputs (one per line):
"string"

;; Desired output:
nil

;; Suggestions:
(-zip "string" nil) ;=> nil
(remq "string" nil) ;=> nil
(last "string" -1) ;=> nil
(assoc "string" nil) ;=> nil
(-take -1 "string") ;=> nil
```

```
;; Inputs (one per line):
'(1 2 3)

;; Desired output:
t

;; Suggestions:
(consp '(1 2 3)) ;=> t
(remove '(1 2 3) t) ;=> t
(-is-infix-p nil '(1 2 3)) ;=> t
(plist-member t '(1 2 3)) ;=> t
(-is-suffix-p nil '(1 2 3)) ;=> t
```

```
;; Inputs (one per line):
'(1 2 3)

;; Desired output:
nil

;; Suggestions:
(-zip '(1 . 2) nil) ;=> nil
(remq '(1 . 2) nil) ;=> nil
(last '(1 . 2) -1) ;=> nil
(assoc '(1 . 2) nil) ;=> nil
(-take -1 '(1 . 2)) ;=> nil
```

```
;; Inputs (one per line):
t

;; Desired output:
t

;; Suggestions:
(last t) ;=> t
(-cons* t) ;=> t
(append t) ;=> t
(-concat t) ;=> t
(identity t) ;=> t
```

```
;; Inputs (one per line):
t

;; Desired output:
nil

;; Suggestions:
(-zip t nil) ;=> nil
(remq t nil) ;=> nil
(last t -1) ;=> nil
(assoc t nil) ;=> nil
(-take -1 t) ;=> nil
```
Note that this PR does NOT solve [#35](https://github.com/Wilfred/suggest.el/issues/35).