### PR TITLE
 Add suggest-insert-example-on-start variable

### DIFF
--- a/suggest.el
+++ b/suggest.el
@@ -386,7 +386,8 @@ we look up `t' instead.")
     ;; Start the overlay after the ";; " bit.
     (let ((overlay (make-overlay (+ 3 start) end)))
       ;; Highlight the text in the heading.
-      (overlay-put overlay 'face 'suggest-heading))))
+      (overlay-put overlay 'face 'suggest-heading)))
+  (insert "\n"))
 
 (defun suggest--on-heading-p ()
   "Return t if point is on a heading."
@@ -427,6 +428,10 @@ we look up `t' instead.")
   "Find the keybinding for COMMAND in KEYMAP."
   (where-is-internal command keymap t))
 
+(defun suggest--insert-section-break ()
+  "Insert section break."
+  (insert "\n\n"))
+
 ;;;###autoload
 (defun suggest ()
   "Open a Suggest buffer that provides suggestions for the inputs
@@ -440,13 +445,19 @@ and outputs given."
     (suggest-mode)
 
     (suggest--insert-heading suggest--inputs-heading)
-    (insert "\n1\n2\n\n")
+    (insert "1\n2")
+
+    (suggest--insert-section-break)
+
     (suggest--insert-heading suggest--outputs-heading)
-    (insert "\n3\n\n")
+    (insert "3")
+
+    (suggest--insert-section-break)
+
     (suggest--insert-heading suggest--results-heading)
-    (insert "\n")
     ;; Populate the suggestions for 1, 2 => 3
     (suggest-update)
+
     ;; Put point on the first input.
     (suggest--nth-heading 1)
     (forward-line 1))

--- a/suggest.el
+++ b/suggest.el
@@ -37,6 +37,21 @@
 (eval-when-compile
   (require 'cl-lib)) ;; cl-incf
 
+(defcustom suggest-insert-example-on-start t
+  "If t, insert example data in suggest buffer, else don't."
+  :group 'suggest
+  :type 'boolean)
+
+(defvar suggest-example-input
+  "1\n2"
+  "The example input data inserted into the suggest buffer on start.
+This should be a string, with multiple inputs separated by a newline.")
+
+(defvar suggest-example-output
+  "3"
+  "The example output data inserted into the suggest buffer on start.
+This should be a string.")
+
 ;; See also `cl--simple-funcs' and `cl--safe-funcs'.
 (defvar suggest-functions
   (list
@@ -445,18 +460,21 @@ and outputs given."
     (suggest-mode)
 
     (suggest--insert-heading suggest--inputs-heading)
-    (insert "1\n2")
+    (when suggest-insert-example-on-start
+      (insert suggest-example-input))
 
     (suggest--insert-section-break)
 
     (suggest--insert-heading suggest--outputs-heading)
-    (insert "3")
+    (when suggest-insert-example-on-start
+      (insert suggest-example-output))
 
     (suggest--insert-section-break)
 
     (suggest--insert-heading suggest--results-heading)
     ;; Populate the suggestions for 1, 2 => 3
-    (suggest-update)
+    (when suggest-insert-example-on-start
+      (suggest-update))
 
     ;; Put point on the first input.
     (suggest--nth-heading 1)


### PR DESCRIPTION
I use `suggest` regularly (I'm pretty handy with Python, but for some reason I can never remember basic string functions in Emacs), so I'm familiar with how it works. It's annoying to have to delete the example data every time I start it, so this PR adds a custom variable to prevent that data from being inserted.