### PR TITLE
Fix erroneous candidate "quote" to cl-case

### DIFF
--- a/suggest.el
+++ b/suggest.el
@@ -832,7 +832,7 @@ than their values."
                 (let ((func-output (plist-get func-result :output)))
                   (cl-case (suggest--classify-output values func-output output)
                     ;; The function gave us the output we wanted, just save it.
-                    ('match
+                    (match
                      (push
                       (list :funcs (cons (list :sym func
                                                :variadic-p (plist-get func-result :variadic-p))
@@ -853,7 +853,7 @@ than their values."
                     ;; The function returned a different result to what
                     ;; we wanted. Build a list of these values so we
                     ;; can explore them.
-                    ('different
+                    (different
                      (when (and
                             (< intermediates-count suggest--max-intermediates)
                             (< (gethash func-output value-occurrences 0)


### PR DESCRIPTION
Passing 'foo as a candidate keylist to cl-case equates to passing (quote foo), which actually means "match the symbol quote or foo". This triggers a new-ish warning in Emacs 30. Although the form in question is matching on the value of suggest--classify-output, which does not ever return the symbol "quote", this is still worth fixing.

Fixes #51.